### PR TITLE
Add supporting docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # self-service-getting-started
-An example Conduktor-self-service setup, to aid in the getting started experience.
+An example Conduktor-self-service setup, this repo accompanies the guide on the [docs.conduktor.io](http://www.docs.conduktor.io/platform/guides/self-service-quickstart/) site.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # self-service-getting-started
-An example Conduktor-self-service setup, this repo accompanies the guide on the [docs.conduktor.io](http://www.docs.conduktor.io/platform/guides/self-service-quickstart/) site.
+An example Conduktor-self-service setup, this repo accompanies the guide on the [docs.conduktor.io](http://docs.conduktor.io/platform/guides/self-service-quickstart/) site.


### PR DESCRIPTION
- [x] Publish docs site
http://docs.conduktor.io/platform/guides/self-service-quickstart/